### PR TITLE
FIX: incompatibilities with OZ 4.4.1

### DIFF
--- a/abi/contracts/F0.sol/F0.json
+++ b/abi/contracts/F0.sol/F0.json
@@ -1,5 +1,10 @@
 [
   {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {
@@ -596,7 +601,7 @@
       },
       {
         "internalType": "bytes",
-        "name": "_data",
+        "name": "data",
         "type": "bytes"
       }
     ],

--- a/abi/contracts/F0ERC721Upgradeable.sol/ERC721Upgradeable.json
+++ b/abi/contracts/F0ERC721Upgradeable.sol/ERC721Upgradeable.json
@@ -228,7 +228,7 @@
       },
       {
         "internalType": "bytes",
-        "name": "_data",
+        "name": "data",
         "type": "bytes"
       }
     ],

--- a/abi/contracts/Factory.sol/Factory.json
+++ b/abi/contracts/Factory.sol/Factory.json
@@ -33,19 +33,13 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "previousOwner",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
       }
     ],
-    "name": "OwnershipTransferred",
+    "name": "Initialized",
     "type": "event"
   },
   {
@@ -133,39 +127,6 @@
       }
     ],
     "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "owner",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "renounceOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
-    ],
-    "name": "transferOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
     "type": "function"
   }
 ]

--- a/contracts/F0.sol
+++ b/contracts/F0.sol
@@ -83,9 +83,13 @@ contract F0 is Initializable, ERC721Upgradeable, OwnableUpgradeable {
 
   /**********************************************************
   *
-  *  INITIALIZER
+  *  INITIALIZER / constructor
   *
   **********************************************************/
+  constructor() {
+    // Disable the Initializers for the implementation contract, so they can not be called outside the proxy's context
+    _disableInitializers();
+  }
   function initialize(string memory name, string memory symbol, Config calldata _config) initializer external {
     __ERC721_init(name, symbol);
     __Ownable_init();
@@ -104,7 +108,7 @@ contract F0 is Initializable, ERC721Upgradeable, OwnableUpgradeable {
   }
   function setNS(string calldata name_, string calldata symbol_) external onlyOwner {
     require(!config.permanent, "2");
-    _name = name_; 
+    _name = name_;
     _symbol = symbol_;
     emit NSUpdated(_name, _symbol);
   }
@@ -113,7 +117,7 @@ contract F0 is Initializable, ERC721Upgradeable, OwnableUpgradeable {
   }
   function setWithdrawer(Withdrawer calldata _withdrawer) external onlyOwner {
     require(!withdrawer.permanent, "3");
-    withdrawer = _withdrawer; 
+    withdrawer = _withdrawer;
     emit WithdrawerUpdated(_withdrawer);
   }
   function setInvites(Invitelist[] calldata invitelist) external onlyOwner {
@@ -261,7 +265,7 @@ contract F0 is Initializable, ERC721Upgradeable, OwnableUpgradeable {
     return string(buffer);
   }
   function verify(Auth calldata auth, address account) internal pure returns (bool) {
-    if (auth.key == "") return true; 
+    if (auth.key == "") return true;
     bytes32 computedHash = keccak256(abi.encodePacked(account));
     for (uint256 i = 0; i < auth.proof.length; i++) {
       bytes32 proofElement = auth.proof[i];

--- a/contracts/F0ERC721Upgradeable.sol
+++ b/contracts/F0ERC721Upgradeable.sol
@@ -4,10 +4,10 @@
 * This file is identical to
 * @openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol
 * with one exception:
-* 
-* _name and _symbol are "internal" types inatead of "private" 
+*
+* _name and _symbol are "internal" types instead of "private"
 *   => so the inheriting F0.sol contract can dynamically update it using setNS()
-* 
+*
 ***************************************************************************************************/
 pragma solidity ^0.8.0;
 
@@ -49,13 +49,11 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
     /**
      * @dev Initializes the contract by setting a `name` and a `symbol` to the token collection.
      */
-    function __ERC721_init(string memory name_, string memory symbol_) internal initializer {
-        __Context_init_unchained();
-        __ERC165_init_unchained();
+    function __ERC721_init(string memory name_, string memory symbol_) internal onlyInitializing {
         __ERC721_init_unchained(name_, symbol_);
     }
 
-    function __ERC721_init_unchained(string memory name_, string memory symbol_) internal initializer {
+    function __ERC721_init_unchained(string memory name_, string memory symbol_) internal onlyInitializing {
         _name = name_;
         _symbol = symbol_;
     }
@@ -65,16 +63,16 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
      */
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165Upgradeable, IERC165Upgradeable) returns (bool) {
         return
-            interfaceId == type(IERC721Upgradeable).interfaceId ||
-            interfaceId == type(IERC721MetadataUpgradeable).interfaceId ||
-            super.supportsInterface(interfaceId);
+        interfaceId == type(IERC721Upgradeable).interfaceId ||
+        interfaceId == type(IERC721MetadataUpgradeable).interfaceId ||
+        super.supportsInterface(interfaceId);
     }
 
     /**
      * @dev See {IERC721-balanceOf}.
      */
     function balanceOf(address owner) public view virtual override returns (uint256) {
-        require(owner != address(0), "ERC721: balance query for the zero address");
+        require(owner != address(0), "ERC721: address zero is not a valid owner");
         return _balances[owner];
     }
 
@@ -83,7 +81,7 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
      */
     function ownerOf(uint256 tokenId) public view virtual override returns (address) {
         address owner = _owners[tokenId];
-        require(owner != address(0), "ERC721: owner query for nonexistent token");
+        require(owner != address(0), "ERC721: invalid token ID");
         return owner;
     }
 
@@ -105,7 +103,7 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
      * @dev See {IERC721Metadata-tokenURI}.
      */
     function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
-        require(_exists(tokenId), "ERC721Metadata: URI query for nonexistent token");
+        _requireMinted(tokenId);
 
         string memory baseURI = _baseURI();
         return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, tokenId.toString())) : "";
@@ -114,7 +112,7 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
     /**
      * @dev Base URI for computing {tokenURI}. If set, the resulting URI for each
      * token will be the concatenation of the `baseURI` and the `tokenId`. Empty
-     * by default, can be overriden in child contracts.
+     * by default, can be overridden in child contracts.
      */
     function _baseURI() internal view virtual returns (string memory) {
         return "";
@@ -129,7 +127,7 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
 
         require(
             _msgSender() == owner || isApprovedForAll(owner, _msgSender()),
-            "ERC721: approve caller is not owner nor approved for all"
+            "ERC721: approve caller is not token owner nor approved for all"
         );
 
         _approve(to, tokenId);
@@ -139,7 +137,7 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
      * @dev See {IERC721-getApproved}.
      */
     function getApproved(uint256 tokenId) public view virtual override returns (address) {
-        require(_exists(tokenId), "ERC721: approved query for nonexistent token");
+        _requireMinted(tokenId);
 
         return _tokenApprovals[tokenId];
     }
@@ -148,10 +146,7 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
      * @dev See {IERC721-setApprovalForAll}.
      */
     function setApprovalForAll(address operator, bool approved) public virtual override {
-        require(operator != _msgSender(), "ERC721: approve to caller");
-
-        _operatorApprovals[_msgSender()][operator] = approved;
-        emit ApprovalForAll(_msgSender(), operator, approved);
+        _setApprovalForAll(_msgSender(), operator, approved);
     }
 
     /**
@@ -170,7 +165,7 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
         uint256 tokenId
     ) public virtual override {
         //solhint-disable-next-line max-line-length
-        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: transfer caller is not owner nor approved");
+        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: caller is not token owner nor approved");
 
         _transfer(from, to, tokenId);
     }
@@ -193,17 +188,17 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
         address from,
         address to,
         uint256 tokenId,
-        bytes memory _data
+        bytes memory data
     ) public virtual override {
-        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: transfer caller is not owner nor approved");
-        _safeTransfer(from, to, tokenId, _data);
+        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: caller is not token owner nor approved");
+        _safeTransfer(from, to, tokenId, data);
     }
 
     /**
      * @dev Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients
      * are aware of the ERC721 protocol to prevent tokens from being forever locked.
      *
-     * `_data` is additional data, it has no specified format and it is sent in call to `to`.
+     * `data` is additional data, it has no specified format and it is sent in call to `to`.
      *
      * This internal function is equivalent to {safeTransferFrom}, and can be used to e.g.
      * implement alternative mechanisms to perform token transfer, such as signature-based.
@@ -221,10 +216,10 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
         address from,
         address to,
         uint256 tokenId,
-        bytes memory _data
+        bytes memory data
     ) internal virtual {
         _transfer(from, to, tokenId);
-        require(_checkOnERC721Received(from, to, tokenId, _data), "ERC721: transfer to non ERC721Receiver implementer");
+        require(_checkOnERC721Received(from, to, tokenId, data), "ERC721: transfer to non ERC721Receiver implementer");
     }
 
     /**
@@ -247,9 +242,8 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
      * - `tokenId` must exist.
      */
     function _isApprovedOrOwner(address spender, uint256 tokenId) internal view virtual returns (bool) {
-        require(_exists(tokenId), "ERC721: operator query for nonexistent token");
         address owner = ERC721Upgradeable.ownerOf(tokenId);
-        return (spender == owner || getApproved(tokenId) == spender || isApprovedForAll(owner, spender));
+        return (spender == owner || isApprovedForAll(owner, spender) || getApproved(tokenId) == spender);
     }
 
     /**
@@ -273,11 +267,11 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
     function _safeMint(
         address to,
         uint256 tokenId,
-        bytes memory _data
+        bytes memory data
     ) internal virtual {
         _mint(to, tokenId);
         require(
-            _checkOnERC721Received(address(0), to, tokenId, _data),
+            _checkOnERC721Received(address(0), to, tokenId, data),
             "ERC721: transfer to non ERC721Receiver implementer"
         );
     }
@@ -304,6 +298,8 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
         _owners[tokenId] = to;
 
         emit Transfer(address(0), to, tokenId);
+
+        _afterTokenTransfer(address(0), to, tokenId);
     }
 
     /**
@@ -328,6 +324,8 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
         delete _owners[tokenId];
 
         emit Transfer(owner, address(0), tokenId);
+
+        _afterTokenTransfer(owner, address(0), tokenId);
     }
 
     /**
@@ -346,29 +344,53 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
         address to,
         uint256 tokenId
     ) internal virtual {
-        require(ERC721Upgradeable.ownerOf(tokenId) == from, "ERC721: transfer of token that is not own");
+        require(ERC721Upgradeable.ownerOf(tokenId) == from, "ERC721: transfer from incorrect owner");
         require(to != address(0), "ERC721: transfer to the zero address");
 
         _beforeTokenTransfer(from, to, tokenId);
 
         // Clear approvals from the previous owner
-        _approve(address(0), tokenId);
+        delete _tokenApprovals[tokenId];
 
         _balances[from] -= 1;
         _balances[to] += 1;
         _owners[tokenId] = to;
 
         emit Transfer(from, to, tokenId);
+
+        _afterTokenTransfer(from, to, tokenId);
     }
 
     /**
      * @dev Approve `to` to operate on `tokenId`
      *
-     * Emits a {Approval} event.
+     * Emits an {Approval} event.
      */
     function _approve(address to, uint256 tokenId) internal virtual {
         _tokenApprovals[tokenId] = to;
         emit Approval(ERC721Upgradeable.ownerOf(tokenId), to, tokenId);
+    }
+
+    /**
+     * @dev Approve `operator` to operate on all of `owner` tokens
+     *
+     * Emits an {ApprovalForAll} event.
+     */
+    function _setApprovalForAll(
+        address owner,
+        address operator,
+        bool approved
+    ) internal virtual {
+        require(owner != operator, "ERC721: approve to caller");
+        _operatorApprovals[owner][operator] = approved;
+        emit ApprovalForAll(owner, operator, approved);
+    }
+
+    /**
+     * @dev Reverts if the `tokenId` has not been minted yet.
+     */
+    function _requireMinted(uint256 tokenId) internal view virtual {
+        require(_exists(tokenId), "ERC721: invalid token ID");
     }
 
     /**
@@ -378,22 +400,23 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
      * @param from address representing the previous owner of the given token ID
      * @param to target address that will receive the tokens
      * @param tokenId uint256 ID of the token to be transferred
-     * @param _data bytes optional data to send along with the call
+     * @param data bytes optional data to send along with the call
      * @return bool whether the call correctly returned the expected magic value
      */
     function _checkOnERC721Received(
         address from,
         address to,
         uint256 tokenId,
-        bytes memory _data
+        bytes memory data
     ) private returns (bool) {
         if (to.isContract()) {
-            try IERC721ReceiverUpgradeable(to).onERC721Received(_msgSender(), from, tokenId, _data) returns (bytes4 retval) {
+            try IERC721ReceiverUpgradeable(to).onERC721Received(_msgSender(), from, tokenId, data) returns (bytes4 retval) {
                 return retval == IERC721ReceiverUpgradeable.onERC721Received.selector;
             } catch (bytes memory reason) {
                 if (reason.length == 0) {
                     revert("ERC721: transfer to non ERC721Receiver implementer");
                 } else {
+                    /// @solidity memory-safe-assembly
                     assembly {
                         revert(add(32, reason), mload(reason))
                     }
@@ -423,5 +446,28 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
         address to,
         uint256 tokenId
     ) internal virtual {}
+
+    /**
+     * @dev Hook that is called after any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _afterTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual {}
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
     uint256[44] private __gap;
 }

--- a/contracts/F0ERC721Upgradeable.sol
+++ b/contracts/F0ERC721Upgradeable.sol
@@ -63,9 +63,9 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
      */
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165Upgradeable, IERC165Upgradeable) returns (bool) {
         return
-        interfaceId == type(IERC721Upgradeable).interfaceId ||
-        interfaceId == type(IERC721MetadataUpgradeable).interfaceId ||
-        super.supportsInterface(interfaceId);
+            interfaceId == type(IERC721Upgradeable).interfaceId ||
+            interfaceId == type(IERC721MetadataUpgradeable).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 
     /**
@@ -350,7 +350,7 @@ contract ERC721Upgradeable is Initializable, ContextUpgradeable, ERC165Upgradeab
         _beforeTokenTransfer(from, to, tokenId);
 
         // Clear approvals from the previous owner
-        delete _tokenApprovals[tokenId];
+        _approve(address(0), tokenId);
 
         _balances[from] -= 1;
         _balances[to] += 1;

--- a/contracts/Factory.sol
+++ b/contracts/Factory.sol
@@ -2,14 +2,15 @@
 pragma solidity ^0.8.4;
 //import 'hardhat/console.sol';
 import "@openzeppelin/contracts-upgradeable/proxy/ClonesUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
 import "./F0.sol";
-contract Factory is OwnableUpgradeable {
+contract Factory is ContextUpgradeable{
   event CollectionAdded(address indexed sender, address indexed receiver, address collection);
   address public immutable implementation;
   constructor() {
     implementation = address(new F0());
-    __Ownable_init();
+    // Disable the Initializers for the implementation contract, so they can not be called outside the proxy's context
+    _disableInitializers();
   }
   /********************************************************************************
   *

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -19,7 +19,7 @@ describe('benchmark', () => {
     })
     await tx.wait()
 
-    let logs = await util.globalLogs() 
+    let logs = await util.globalLogs()
     let lastLog = logs[logs.length-1];
     let hex = "1220" + lastLog.args.cid.slice(2)
 

--- a/test/burn.js
+++ b/test/burn.js
@@ -30,7 +30,7 @@ describe('burn tokens', () => {
     await tx.wait()
     // The token should not exist
     owner = util.token.ownerOf(1)
-    await expect(owner).to.be.revertedWith("ERC721: owner query for nonexistent token")
+    await expect(owner).to.be.revertedWith("ERC721: invalid token ID")
   })
   it('cannot burn token if you are not the owner', async () => {
     await util.deploy();

--- a/test/gift.js
+++ b/test/gift.js
@@ -52,11 +52,11 @@ describe('gift', () => {
     // nextId should be 2 because 1 has been minted
     let nextId = await util.token.nextId()
     expect(nextId.toString()).to.equal("2")
-    let owner = await util.token.ownerOf(1) 
+    let owner = await util.token.ownerOf(1)
     expect(owner).to.equal(util.bob.address)
 
-    owner = util.token.ownerOf(2) 
-    await expect(owner).to.be.revertedWith("ERC721: owner query for nonexistent token")
+    owner = util.token.ownerOf(2)
+    await expect(owner).to.be.revertedWith("ERC721: invalid token ID")
 
   })
   it('gift two tokens and check nextId', async () => {
@@ -74,11 +74,11 @@ describe('gift', () => {
     let nextId = await util.token.nextId()
     expect(nextId.toString()).to.equal("3")
     for(let i=1; i<=2; i++) {
-      let owner = await util.token.ownerOf(i) 
+      let owner = await util.token.ownerOf(i)
       expect(owner).to.equal(util.bob.address)
     }
     let owner = util.token.ownerOf(3)
-    await expect(owner).to.be.revertedWith("ERC721: owner query for nonexistent token")
+    await expect(owner).to.be.revertedWith("ERC721: invalid token ID")
   })
   it('gift tokens to alice', async () => {
     await util.deploy();
@@ -92,7 +92,7 @@ describe('gift', () => {
     await tx.wait()
     // the 3 tokens are now owned by bob
     for(let i=1; i<=3; i++) {
-      let owner = await util.token.ownerOf(i) 
+      let owner = await util.token.ownerOf(i)
       expect(owner).to.equal(util.bob.address)
     }
   })

--- a/test/invite.js
+++ b/test/invite.js
@@ -323,7 +323,7 @@ describe('invite', () => {
 
     // total balance of alice is 4
     let b = await aliceToken.balanceOf(util.alice.address)
-    console.log(b)
+    //console.log(b)
     expect(b).to.equal(4)
 
     // try to mint even more with presale => wont work
@@ -335,7 +335,7 @@ describe('invite', () => {
     })
     await expect(tx).to.be.revertedWith("10")
 
-    // try to mint even more with airdrop => won't work 
+    // try to mint even more with airdrop => won't work
     tx = aliceToken.mint({
       key: key1,
       proof: proof1
@@ -409,7 +409,7 @@ describe('invite', () => {
 
 
 
-    
+
   })
   it("should not allow people to mint multiple times after transferring their tokens", async () => {
     // when the invite list policy is dictated by the current balance of the minter,
@@ -464,7 +464,7 @@ describe('invite', () => {
 
     // owner of token 1 is alice
     let owner = await aliceToken.ownerOf(1)
-    console.log(owner)
+    //console.log(owner)
     expect(owner).to.be.equal(util.alice.address)
 
     // Transfer to another address, and then try to mint 1 => should NOT go through

--- a/test/mint.js
+++ b/test/mint.js
@@ -16,7 +16,7 @@ describe('mint', () => {
       key: util.all,
       proof: [],
     }, 1)
-    await expect(tx).to.be.revertedWith("10") 
+    await expect(tx).to.be.revertedWith("10")
 
     let nextId = await util.token.nextId()
     expect(nextId.toString()).to.equal("0")
@@ -185,7 +185,7 @@ describe('mint', () => {
 
     // token 4 doesn't exist
     tx = util.token.ownerOf(4)
-    await expect(tx).to.be.revertedWith("ERC721: owner query for nonexistent token")
+    await expect(tx).to.be.revertedWith("ERC721: invalid token ID")
   })
   it('mint multiple times', async () => {
     await util.deploy();
@@ -332,7 +332,7 @@ describe('mint', () => {
 
     // try to mint 1 while paying too much => fail
     tx = util.token.mint({
-      account: util.alice.address, 
+      account: util.alice.address,
       key: util.all,
       proof: [],
     }, 1, {

--- a/test/nextid.js
+++ b/test/nextid.js
@@ -33,7 +33,7 @@ const pubInvite = async () => {
     limit: 300,
   })
   await tx.wait()
-  return { key: util.all, proof: [] } 
+  return { key: util.all, proof: [] }
 }
 describe('nextId edge case testing', () => {
   describe('gift', () => {
@@ -53,13 +53,13 @@ describe('nextId edge case testing', () => {
       await util.token.mint(auth, 1)
 
       // tokenId 1 owned by deployer
-      let owner = await util.token.ownerOf(1) 
+      let owner = await util.token.ownerOf(1)
       expect(owner).to.equal(util.deployer.address)
 
       // tokenId 2 doesn't exist
-      owner = util.token.ownerOf(2) 
-      await expect(owner).to.be.revertedWith("ERC721: owner query for nonexistent token")
-      
+      owner = util.token.ownerOf(2)
+      await expect(owner).to.be.revertedWith("ERC721: invalid token ID")
+
       // nextId should be 2
       let nextId = await util.token.nextId()
       expect(nextId).to.equal(2)
@@ -161,13 +161,13 @@ describe('nextId edge case testing', () => {
       await util.token.gift(util.alice.address, 1)
 
       // tokenId 1 owned by alice
-      let owner = await util.token.ownerOf(1) 
+      let owner = await util.token.ownerOf(1)
       expect(owner).to.equal(util.alice.address)
 
       // tokenId 2 doesn't exist
-      owner = util.token.ownerOf(2) 
-      await expect(owner).to.be.revertedWith("ERC721: owner query for nonexistent token")
-      
+      owner = util.token.ownerOf(2)
+      await expect(owner).to.be.revertedWith("ERC721: invalid token ID")
+
       // nextId should be 2
       let nextId = await util.token.nextId()
       expect(nextId).to.equal(2)
@@ -189,7 +189,7 @@ describe('nextId edge case testing', () => {
     it('private invite => mint 0 => nextId should be 1', async () => {
       await deploy()
       let auth = await privInvite(util.alice.address)
-      console.log("auth", auth)
+      //console.log("auth", auth)
       let aliceToken = util.getToken(util.alice)
       await aliceToken.mint(auth, 0)
       let nextId = await util.token.nextId()

--- a/test/withdraw.js
+++ b/test/withdraw.js
@@ -321,7 +321,7 @@ describe('withdraw', () => {
     // Step 5. 10ETH * 100 => 1000 ETH revenue => The 1ETH fee cap has been reached so no more fee going forward:  0 fee
     await invite(Math.pow(10, 19))
     factoriaBalanceBefore = await ethers.provider.getBalance(FACTORIA);
-    r = await makeMoney(Math.pow(10, 18)*10, 100, true)   // make money without redeploying  
+    r = await makeMoney(Math.pow(10, 18)*10, 100, true)   // make money without redeploying
     factoriaBalanceAfter = await ethers.provider.getBalance(FACTORIA);
 
     // Final result is equal to


### PR DESCRIPTION
- **Factory.sol:** removed the the OwnableUpgradeable inheritance as it was not being used
- **Factory.sol:** updated so its compatible with the breaking changes introduced in openzeppelin-contracts-upgradeable 4.4.1


- **F0.sol**: make the constructor disable the Initializers. This is just a precaution as it prevents the initializer from being run on the implementation contract's context. Right now that would be harmless, but we are making sure we don't get any nasty surprises in the future (like the Parity Multi-Sig Library Self-Destruct). This is not a problem for the cloned contracts, as the factory calls the initializer during genesis (so it's part of the same TXn) so it's impossible for a bad actor to take over a clone.
- **F0.sol:** Removed some trailing whitespaces


- **F0ERC721Upgradeable.sol**: pulled the latest version of this contract (e0e0a04) from oz so it's compatible with the breaking changes introduced on 4.4.1.
- _name and _symbol are kept as internal (in the oz contract are private)